### PR TITLE
making streams end so we can test them

### DIFF
--- a/experiments/stream_command.py
+++ b/experiments/stream_command.py
@@ -1,4 +1,3 @@
-
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 import itertools
@@ -10,6 +9,7 @@ import uvicorn
 stream_yes = FastAPI()
 
 blocksize = int(1024 * 1024 / 4)
+
 
 async def stream_command_async(proc, logger=None, blksize=blocksize):
     """
@@ -51,9 +51,10 @@ async def get_stream_yes():
     Run the yes command and stream results. Yes runs forever so this should be an
     infinite stream.
     """
-    cmd = ["yes"]
-    proc = await asyncio.create_subprocess_exec(*cmd,
-                                                stdout=asyncio.subprocess.PIPE)
+    cmd = "yes | head -n1000"
+    proc = await asyncio.create_subprocess_exec(
+        *["bash", "-c", cmd], stdout=asyncio.subprocess.PIPE
+    )
     stream_gen = stream_command_async(proc)
     return StreamingResponse(stream_gen)
 
@@ -63,7 +64,7 @@ async def get_stream_yes_fake():
     """
     Returns an infinite stream of "y"
     """
-    y_gen = itertools.repeat("y")
+    y_gen = itertools.repeat("y", 1000)
     return StreamingResponse(y_gen)
 
 


### PR DESCRIPTION
I made the streams end. if they don't end we never exit the response and cannot test them.  also had to fiddle with the tests in order to get them to see the stream as separate lines (at least with the `stream_yes_fake`).

there might be a way to do what you were originally doing with asyncio "tasks" similar to how the streamingresponse get's run: https://github.com/encode/starlette/blob/master/starlette/responses.py#L238-L241 and https://github.com/encode/starlette/blob/c566fc6c819f0d565f8cff432351fe009e83d866/starlette/concurrency.py#L16

maybe if you ran the fastapi app inside a asyncio taskpool you could possibly capture the stream as it's coming out the way you originally had things.  that would be an interesting experiment!